### PR TITLE
Use default max packet size for SFTP

### DIFF
--- a/nmon2influxdblib/files.go
+++ b/nmon2influxdblib/files.go
@@ -32,7 +32,6 @@ var delimiterRegexp = regexp.MustCompile(`^\w+(.)`)
 var statsRegexp = regexp.MustCompile(`\W(T\d{4,16})`)
 
 const gzipfile = ".gz"
-const size = 64000
 
 // File structure used to select nmon files to import
 type File struct {
@@ -256,7 +255,7 @@ func InitSFTP(sshUser string, host string, key string) *sftp.Client {
 		log.Fatalf("dial failed:%v", err)
 	}
 
-	c, err := sftp.NewClient(conn, sftp.MaxPacket(size))
+	c, err := sftp.NewClient(conn)
 	if err != nil {
 		log.Fatalf("unable to start sftp subsytem: %v", err)
 	}


### PR DESCRIPTION
This pull request changes `nmon2influxdb` so it uses the default MaxPacket size from from `pkg/sftp`.

A change to `pkg/sftp` ([this commit](https://github.com/pkg/sftp/commit/f8a9ce48adbf1372f8ceceae1020a4aee1f905e4)) made in January broke `nmon2influxdb`'s capacity to fetch remote files.

The reason is that the MaxPacket size used by `nmon2influxdb`, 64000 bytes, is too high. Changing it to any value less than or equal to 32768 bytes (=32KiB) would fix the problem.

I think a cleaner solution is to use the default package size from `pkg/sftp`, which is 32768 bytes. The MaxPacket parameter is no longer required when creating a new SFTP client.