### PR TITLE
Added HMC logoff feature to avoid REST API idling session

### DIFF
--- a/hmc/import.go
+++ b/hmc/import.go
@@ -286,4 +286,5 @@ func Import(c *cli.Context) {
 			}
 		}
 	}
+	hmc.Session.DoLogoff(hmc.Token)
 }


### PR DESCRIPTION
Hi,

This request is related to issue #73.
This is my first pull request and the first time I try to contribute to a Go project, please bear this in mind in case I'm not doing it right :) 
This will not be the prettiest code !

This has been tested on my side successfully, there are no more idling session_id on the HMC.
```
lslogon -r webui -u | grep -i rest
```

Thanks,
Julien